### PR TITLE
Revert "Correct shared library suffix on macOS"

### DIFF
--- a/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/stf/SharedClassesAPI.java
+++ b/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/stf/SharedClassesAPI.java
@@ -213,15 +213,8 @@ public class SharedClassesAPI implements SharedClassesPluginInterface {
 				//    due to: https://github.com/eclipse-openj9/openj9-systemtest/issues/38 
 				if ( !PlatformFinder.isWindows() ) {
 					// Verify caches using a JVMTI native agent
-					String nativeExt;
-					if (PlatformFinder.isOSX()) {
-						nativeExt = ".dylib";
-					} else if (PlatformFinder.isWindows()) {
-						nativeExt = ".dll";
-					} else {
-						nativeExt = ".so";
-					}
-					String nativePrefix = PlatformFinder.isWindows() ? "" : "lib";
+					String nativeExt    =  PlatformFinder.isWindows() ? ".dll" : ".so";
+					String nativePrefix =  PlatformFinder.isWindows() ? "" : "lib";
 					FileRef agent = test.env().findTestDirectory("openj9.test.sharedClasses.jvmti/bin/native")
 							.childDirectory(test.env().getPlatformSimple())
 							.childFile(nativePrefix + "sharedClasses" + nativeExt);


### PR DESCRIPTION
Reverts adoptium/openj9-systemtest#158