### PR TITLE
Revert "Temporarily exclude native sharedClasses tests on Windows"

### DIFF
--- a/openj9.test.sharedClasses.jvmti/build.xml
+++ b/openj9.test.sharedClasses.jvmti/build.xml
@@ -71,13 +71,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<target name="build-no-natives" depends="check-prereqs, build-dependencies, check-prereqs, build-archives">
 	</target>
 
-	<!--Temporarily excluding the native tests from building on Windows 
-			 due to : https://github.com/eclipse-openj9/openj9-systemtest/issues/38 --> 
 	<target name="build-natives" depends="check-prereqs, setup-native-build-command, build-natives-windows, build-natives-unix">
 	</target>
-	
-	<!-- <target name="build-natives" depends="check-prereqs, setup-native-build-command, build-natives-unix">
-	</target> -->
 
 	<target name="setup-native-build-command">
 		<echo message="building natives for java-platform ${java_platform}"/>

--- a/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/stf/SharedClassesAPI.java
+++ b/openj9.test.sharedClasses.jvmti/src/test.sharedClasses.jvmti/net/openj9/stf/SharedClassesAPI.java
@@ -209,28 +209,24 @@ public class SharedClassesAPI implements SharedClassesPluginInterface {
 							.addProjectToClasspath("openj9.test.sharedClasses.jvmti")
 							.runClass(SharedClassesCacheChecker.class));
 			} else {
-				// Temporarily excluding the native tests from running on Windows 
-				//    due to: https://github.com/eclipse-openj9/openj9-systemtest/issues/38 
-				if ( !PlatformFinder.isWindows() ) {
-					// Verify caches using a JVMTI native agent
-					String nativeExt    =  PlatformFinder.isWindows() ? ".dll" : ".so";
-					String nativePrefix =  PlatformFinder.isWindows() ? "" : "lib";
-					FileRef agent = test.env().findTestDirectory("openj9.test.sharedClasses.jvmti/bin/native")
-							.childDirectory(test.env().getPlatformSimple())
-							.childFile(nativePrefix + "sharedClasses" + nativeExt);
-					
-					if (!cacheDir.isEmpty()) {
-						cacheDir = "," + cacheDir;
-					}
-					String agentOptions = "expectedCacheCount=" + apiTest.expectedCacheCount + ","
-							+ "deleteCaches=true,"
-							+ "cachePrefix=" + apiTest.name() + cacheDir;
-					
-					sharedClasses.doVerifyCachesUsingJVMTI(commentPrefix + "Verify caches using JVMTI",
-							apiTest.name(), 
-							sharedClassesOption,
-							"-agentpath:" + agent + "=" + agentOptions);
+				// Verify caches using a JVMTI native agent
+				String nativeExt    =  PlatformFinder.isWindows() ? ".dll" : ".so";
+				String nativePrefix =  PlatformFinder.isWindows() ? "" : "lib";
+				FileRef agent = test.env().findTestDirectory("openj9.test.sharedClasses.jvmti/bin/native")
+						.childDirectory(test.env().getPlatformSimple())
+						.childFile(nativePrefix + "sharedClasses" + nativeExt);
+				
+				if (!cacheDir.isEmpty()) {
+					cacheDir = "," + cacheDir;
 				}
+				String agentOptions = "expectedCacheCount=" + apiTest.expectedCacheCount + ","
+						+ "deleteCaches=true,"
+						+ "cachePrefix=" + apiTest.name() + cacheDir;
+				
+				sharedClasses.doVerifyCachesUsingJVMTI(commentPrefix + "Verify caches using JVMTI",
+						apiTest.name(), 
+						sharedClassesOption,
+						"-agentpath:" + agent + "=" + agentOptions);
 			}
 		}
 	}


### PR DESCRIPTION
This reverts commit ef15ae73e9b6a98e57a210dfd50ece8d48f0c79f.

Closes: https://github.com/adoptium/openj9-systemtest/issues/157